### PR TITLE
Make providing a Test-Target optional.

### DIFF
--- a/src/main/java/org/moe/editors/XcodeEditorManager.java
+++ b/src/main/java/org/moe/editors/XcodeEditorManager.java
@@ -108,6 +108,7 @@ public class XcodeEditorManager {
     private void setXCBuildConfigurations() {
         this.mainReleaseXCBuildConfiguration = getXCBuildConfiguration(mainTarget, RELEASE);
         this.mainDebugXCBuildConfiguration = getXCBuildConfiguration(mainTarget, DEBUG);
+        if (testTarget == null) return;
         this.testReleaseXCBuildConfiguration = getXCBuildConfiguration(testTarget, RELEASE);
         this.testDebugXCBuildConfiguration = getXCBuildConfiguration(testTarget, DEBUG);
     }
@@ -138,6 +139,10 @@ public class XcodeEditorManager {
         if (documentChangeListener != null) {
             documentChangeListener.documentChanged();
         }
+    }
+
+    public boolean hasTestTarget(){
+        return testTarget != null;
     }
 
     public String getTestTargetName() {


### PR DESCRIPTION
These changes consists of two pr's.
The current state is that if no test target is provided in the project.pbxproj the file isn't openable with the ide without giving any further information. These changes let the user open the project.pbxproj file but still hints him to provide a test target.

This fixes multi-os-engine/multi-os-engine#127